### PR TITLE
Add test 13 info

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,7 @@ Test repository for github actions
 ## Test 12
 - Se agrego comandos para imprimir variables disponibles.
 ### Resultado
+- Funciono bien, se identifico que se fallo antes al imprimir el cuerpo del pr porque parte del texto era interpretado como un comando en vez de ser solo string. Solucion encerrar la variable en comillas.
 
+## Test 13
+- se agrego acciones para guardar en cache los pods


### PR DESCRIPTION
## Que se hizo
- Anteriormente se agrego un step para guardar en cache los pods. Como no existia ningun cache en esa execucion paso con un cache-hit distinto de `'true'`.
- Se agrego a env el token de github disponible en la action.